### PR TITLE
Fix typo 'About this side' to 'About this site'

### DIFF
--- a/de/map.html
+++ b/de/map.html
@@ -87,7 +87,7 @@
         code: "de",
         minZoomMessageNoLayer: "Keine Ebene zugewiesen",
         minZoomMessage: "Vergrössern, um Standorte zu laden",
-        aboutThisSide: "Über diese Seite",
+        aboutThisSite: "Über diese Seite",
         capacity: "Kapazität",
         freeToTake: "Nur mitnehmen",
         freeToTakeOrGive: "Mitnehmen und bringen",

--- a/map.html
+++ b/map.html
@@ -87,7 +87,7 @@
         code: "",
         minZoomMessageNoLayer: "No layer assigned",
         minZoomMessage: "Zoom in to load locations",
-        aboutThisSide: "About this side",
+        aboutThisSite: "About this site",
         capacity: "Capacity",
         freeToTake: "Free to take",
         freeToTakeOrGive: "Free to take or give",

--- a/script.js
+++ b/script.js
@@ -4,8 +4,8 @@ var locate;
 function publicBookCaseMap(local) {
   moment.locale(local.code || "en");
 
-  let attr_side = `<a href="https://public-bookcase.github.io/${local.code}">${
-    local.aboutThisSide
+  let attr_site = `<a href="https://public-bookcase.github.io/${local.code}">${
+    local.aboutThisSite
   }</a>`;
   let attr_osm =
     'Map data &copy; <a href="https://openstreetmap.org/">OpenStreetMap</a> contributors';
@@ -16,7 +16,7 @@ function publicBookCaseMap(local) {
     "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
     {
       opacity: 0.7,
-      attribution: [attr_side, attr_osm, attr_overpass].join(" | ")
+      attribution: [attr_site, attr_osm, attr_overpass].join(" | ")
     }
   );
 


### PR DESCRIPTION
Hi, there is a typo error in the english version of the website.

At the bottom of the map, there is the text "About this side". But I think the correct text is "About this site" or "About this website".

Thank you for your map and have a nice day